### PR TITLE
Fingerprint deltas

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,4 +2,3 @@
 
 - Using `cargo clippy` will fail if `clippy` wasn't installed by `rustup`. This situation is difficult to detect
 because there is an existing `clippy` install on the Github runners that fails to function.
-- It looks as if cargo-install build artifacts are dependent on the index, even though it does not appear that the index change affected any relied-upon crates.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,3 +2,4 @@
 
 - Using `cargo clippy` will fail if `clippy` wasn't installed by `rustup`. This situation is difficult to detect
 because there is an existing `clippy` install on the Github runners that fails to function.
+- It looks as if cargo-install build artifacts are dependent on the index, even though it does not appear that the index change affected any relied-upon crates.

--- a/src/cargo_install_hook.rs
+++ b/src/cargo_install_hook.rs
@@ -100,6 +100,8 @@ impl CargoHook for CargoInstallHook {
                             old_fingerprint.content_hash(),
                             new_fingerprint.content_hash()
                         );
+                        let delta = new_fingerprint.changes_from(&old_fingerprint);
+                        info!("Changes: {:#?}", delta);
                     }
                     changed
                 }

--- a/src/cargo_install_hook.rs
+++ b/src/cargo_install_hook.rs
@@ -118,7 +118,7 @@ impl CargoHook for CargoInstallHook {
                             new_fingerprint.content_hash()
                         );
                         let delta = new_fingerprint.changes_from(old_fingerprint);
-                        info!("Changes:\n{}", render_delta_items(&delta));
+                        info!("{}", render_delta_items(&delta));
                     }
                     changed
                 }

--- a/src/cargo_install_hook.rs
+++ b/src/cargo_install_hook.rs
@@ -1,7 +1,7 @@
 use crate::action_paths::get_action_cache_dir;
 use crate::actions::cache::CacheEntry;
 use crate::cargo_hook::CargoHook;
-use crate::fingerprinting::Fingerprint;
+use crate::fingerprinting::{render_delta_items, Fingerprint};
 use crate::node::path::Path;
 use crate::{actions, error, info, node, warning, Error};
 use async_trait::async_trait;
@@ -59,9 +59,9 @@ impl CargoInstallHook {
         use crate::fingerprinting::{fingerprint_directory_with_ignores, Ignores};
 
         // It seems that between runs something causes the rustc fingerprint to change.
-        // It looks like this could simply be the file modification timestamp. This would
-        // also explain why it seemed to occur with Rustup but not the internal toolchain
-        // downloader.
+        // It looks like this could simply be the file modification timestamp. This
+        // would also explain why it seemed to occur with Rustup but not the
+        // internal toolchain downloader.
         //
         // https://github.com/rust-lang/cargo/blob/70898e522116f6c23971e2a554b2dc85fd4c84cd/src/cargo/util/rustc.rs#L306
 
@@ -118,7 +118,7 @@ impl CargoHook for CargoInstallHook {
                             new_fingerprint.content_hash()
                         );
                         let delta = new_fingerprint.changes_from(&old_fingerprint);
-                        info!("Changes: {:#?}", delta);
+                        info!("Changes:\n{}", render_delta_items(&delta));
                     }
                     changed
                 }

--- a/src/cargo_install_hook.rs
+++ b/src/cargo_install_hook.rs
@@ -1,7 +1,7 @@
 use crate::action_paths::get_action_cache_dir;
 use crate::actions::cache::CacheEntry;
 use crate::cargo_hook::CargoHook;
-use crate::fingerprinting::fingerprint_directory;
+use crate::fingerprinting::{fingerprint_directory, Fingerprint};
 use crate::node::path::Path;
 use crate::{actions, error, info, node, warning, Error};
 use async_trait::async_trait;
@@ -21,7 +21,7 @@ pub struct CargoInstallHook {
     hash: HashValue,
     nonce: HashValue,
     build_dir: String,
-    fingerprint: Option<u64>,
+    fingerprint: Option<Fingerprint>,
 }
 
 impl CargoInstallHook {
@@ -50,7 +50,7 @@ impl CargoInstallHook {
         let cache_entry = result.build_cache_entry();
         if let Some(key) = cache_entry.restore().await? {
             info!("Restored files from cache with key {}", key);
-            result.fingerprint = Some(fingerprint_directory(&build_dir).await?.content_hash());
+            result.fingerprint = Some(fingerprint_directory(&build_dir).await?);
         }
         Ok(result)
     }
@@ -89,16 +89,16 @@ impl CargoHook for CargoInstallHook {
     }
 
     async fn succeeded(&mut self) {
-        let save = if let Some(old_fingerprint) = self.fingerprint {
+        let save = if let Some(old_fingerprint) = &self.fingerprint {
             let path = Path::from(self.build_dir.as_str());
             match fingerprint_directory(&path).await.map_err(Error::Js) {
-                Ok(fingerprint) => {
-                    let new_fingerprint = fingerprint.content_hash();
-                    let changed = new_fingerprint != old_fingerprint;
+                Ok(new_fingerprint) => {
+                    let changed = new_fingerprint.content_hash() != old_fingerprint.content_hash();
                     if changed {
                         info!(
                             "Package artifact cache changed fingerprint from {} to {}",
-                            old_fingerprint, new_fingerprint
+                            old_fingerprint.content_hash(),
+                            new_fingerprint.content_hash()
                         );
                     }
                     changed

--- a/src/cargo_install_hook.rs
+++ b/src/cargo_install_hook.rs
@@ -117,7 +117,7 @@ impl CargoHook for CargoInstallHook {
                             old_fingerprint.content_hash(),
                             new_fingerprint.content_hash()
                         );
-                        let delta = new_fingerprint.changes_from(&old_fingerprint);
+                        let delta = new_fingerprint.changes_from(old_fingerprint);
                         info!("Changes:\n{}", render_delta_items(&delta));
                     }
                     changed


### PR DESCRIPTION
* Show which files were added/changed/removed when re-caching `cargo install` artifacts.
* Fix re-caching issue due to compiler fingerprint changing.