### PR TITLE
Improve rustup support/actions-rs consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           command: install-rustup
           toolchain: nightly
           profile: minimal
-          targets: wasm32-unknown-unknown
+          target: wasm32-unknown-unknown
           components: clippy
           default: true
       - id: install-grcov

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   profile:
     description: 'A profile that selects components (minimal, default, complete)'
     required: false
-  targets:
+  target:
     description: 'Targets to install e.g. x86_64-unknown-linux-gnu'
     required: false
   default:

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,9 @@ pub enum Error {
 
     #[error("Required input was not supplied: {0}")]
     MissingInput(String),
+
+    #[error("Toolchain install backend does not support {0} functionality")]
+    ToolchainInstallFunctionality(String),
 }
 
 impl From<JsValue> for Error {

--- a/src/input_manager.rs
+++ b/src/input_manager.rs
@@ -33,6 +33,9 @@ pub enum Input {
     #[strum(serialize = "min-recache-indices")]
     MinRecacheIndices,
 
+    #[strum(serialize = "override")]
+    Override,
+
     #[strum(serialize = "profile")]
     Profile,
 

--- a/src/input_manager.rs
+++ b/src/input_manager.rs
@@ -36,7 +36,8 @@ pub enum Input {
     #[strum(serialize = "profile")]
     Profile,
 
-    #[strum(serialize = "targets")]
+    // We name this target instead of targets since actions-rs only has target
+    #[strum(serialize = "target")]
     Targets,
 
     #[strum(serialize = "toolchain")]

--- a/src/run.rs
+++ b/src/run.rs
@@ -22,8 +22,14 @@ fn get_toolchain_config(input_manager: &InputManager) -> Result<ToolchainConfig,
     if let Some(set_default) = input_manager.get(Input::Default) {
         let set_default = set_default
             .parse::<bool>()
-            .map_err(|_| Error::OptionParseError("default".into(), set_default.to_string()))?;
-        toolchain_config.default = set_default;
+            .map_err(|_| Error::OptionParseError(Input::Default.to_string(), set_default.to_string()))?;
+        toolchain_config.set_default = set_default;
+    }
+    if let Some(set_override) = input_manager.get(Input::Override) {
+        let set_override = set_override
+            .parse::<bool>()
+            .map_err(|_| Error::OptionParseError(Input::Override.to_string(), set_override.to_string()))?;
+        toolchain_config.set_override = set_override;
     }
     Ok(toolchain_config)
 }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -21,7 +21,8 @@ pub struct ToolchainConfig {
     pub profile: String,
     pub components: Vec<String>,
     pub targets: Vec<String>,
-    pub default: bool,
+    pub set_default: bool,
+    pub set_override: bool,
 }
 
 impl Default for ToolchainConfig {
@@ -31,7 +32,8 @@ impl Default for ToolchainConfig {
             profile: "default".into(),
             components: Vec::new(),
             targets: Vec::new(),
-            default: false,
+            set_default: true,
+            set_override: false,
         }
     }
 }
@@ -117,13 +119,15 @@ impl Rustup {
             args.extend(["-c".into(), component.clone()]);
         }
         Command::from(&self.path).args(args).exec().await.map_err(Error::Js)?;
-        if config.default {
-            Command::from(&self.path)
-                .arg("default")
-                .arg(config.name.clone())
-                .exec()
-                .await
-                .map_err(Error::Js)?;
+        for (flag, option_name) in [(config.set_default, "default"), (config.set_override, "override")] {
+            if flag {
+                Command::from(&self.path)
+                    .arg(option_name)
+                    .arg(config.name.clone())
+                    .exec()
+                    .await
+                    .map_err(Error::Js)?;
+            }
         }
         Ok(())
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -184,9 +184,14 @@ pub async fn install(toolchain_config: &ToolchainConfig) -> Result<(), Error> {
         .buffer_unordered(MAX_CONCURRENT_PACKAGE_INSTALLS);
     process_packages.try_collect().await?;
 
-    if toolchain_config.default {
+    if toolchain_config.set_default {
         let cargo_bin = get_cargo_home(&toolchain)?.join("bin");
         actions::core::add_path(&cargo_bin);
+    } else {
+        return Err(Error::ToolchainInstallFunctionality("default=false".into()));
+    }
+    if toolchain_config.set_override {
+        return Err(Error::ToolchainInstallFunctionality("override".into()));
     }
     Ok(())
 }


### PR DESCRIPTION
* Rename `targets` to `target`.
* Support `override`.
* Make internal toolchain installer reject `override=true` and `default=false`.