### PR TITLE
Handle different jobs having different sets of dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        key: [singleton]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        key: [singleton]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "simple-path-match"
 version = "0.1.0"
-source = "git+https://github.com/FrancisRussell/simple-path-match.git?rev=aa9a9b04fa2bd628757a95399bfdc1ebe40ab7f5#aa9a9b04fa2bd628757a95399bfdc1ebe40ab7f5"
+source = "git+https://github.com/FrancisRussell/simple-path-match.git?rev=22d1d28ed11cb1de600c29bd34937a2bcb32b37b#22d1d28ed11cb1de600c29bd34937a2bcb32b37b"
 dependencies = [
  "itertools",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -529,9 +529,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "link-cplusplus"
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "os_str_bytes"
@@ -665,18 +665,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -734,15 +734,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scoped-tls"
@@ -764,27 +764,27 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -869,9 +869,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -895,18 +895,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -930,9 +930,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rev = "5c84a85f48e2a0b236e84b2241854372c996cf31"
 
 [dependencies.simple-path-match]
 git = "https://github.com/FrancisRussell/simple-path-match.git"
-rev = "aa9a9b04fa2bd628757a95399bfdc1ebe40ab7f5"
+rev = "22d1d28ed11cb1de600c29bd34937a2bcb32b37b"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,15 @@ inputs:
   use-cross:
     description: 'Whether cross should be used in place of cargo'
     required: false
+  internal-use-github-workflow:
+    description: 'DO NOT SET THIS INPUT - used to detect the workflow name'
+    default: ${{ toJSON(github.workflow) }}
+  internal-use-github-job:
+    description: 'DO NOT SET THIS INPUT - used to detect the job ID'
+    default: ${{ toJSON(github.job) }}
+  internal-use-matrix:
+    description: 'DO NOT SET THIS INPUT - used to identify matrix properties'
+    default: ${{ toJSON(matrix) }}
 outputs:
   result:
     description: 'The result of the action execution'

--- a/src/cache_cargo_home.rs
+++ b/src/cache_cargo_home.rs
@@ -200,6 +200,7 @@ fn build_cache_entry(cache_type: CacheType, key: &HashValue, path: &Path) -> Cac
 }
 
 pub async fn restore_cargo_cache(input_manager: &input_manager::Manager) -> Result<(), Error> {
+    /*
     use crate::access_times::{revert_folder, supports_atime};
     use crate::cargo_lock_hashing::hash_cargo_lock_files;
 
@@ -277,10 +278,12 @@ pub async fn restore_cargo_cache(input_manager: &input_manager::Manager) -> Resu
         node::fs::create_dir_all(&parent).await?;
         node::fs::write_file(&folder_info_path, folder_info_serialized.as_bytes()).await?;
     }
+    */
     Ok(())
 }
 
 pub async fn save_cargo_cache(input_manager: &input_manager::Manager) -> Result<(), Error> {
+    /*
     use humantime::format_duration;
     use wasm_bindgen::JsError;
 
@@ -392,5 +395,6 @@ pub async fn save_cargo_cache(input_manager: &input_manager::Manager) -> Result<
             }
         }
     }
+    */
     Ok(())
 }

--- a/src/cache_cargo_home.rs
+++ b/src/cache_cargo_home.rs
@@ -62,6 +62,8 @@ impl Cache {
     }
 
     async fn build_entry(cache_type: CacheType, entry_path: &Path) -> Result<Fingerprint, Error> {
+        use crate::access_times::revert_folder;
+        revert_folder(&entry_path).await?;
         let ignores = cache_type.ignores();
         fingerprint_path_with_ignores(entry_path, &ignores).await
     }

--- a/src/cache_cargo_home.rs
+++ b/src/cache_cargo_home.rs
@@ -211,6 +211,8 @@ fn build_cache_entry(cache_type: CacheType, key: &HashValue, path: &Path) -> Cac
 }
 
 pub async fn restore_cargo_cache(input_manager: &input_manager::Manager) -> Result<(), Error> {
+    use crate::job::Job;
+
     let cached_types = get_types_to_cache(input_manager)?;
     for cache_type in cached_types {
         let folder_path = find_path(cache_type);
@@ -219,6 +221,8 @@ pub async fn restore_cargo_cache(input_manager: &input_manager::Manager) -> Resu
         let entry_paths = match_relative_paths(&folder_path, &entry_matcher).await?;
         info!("Cache entries for {}: {:#?}", cache_type, entry_paths);
     }
+    let job = Job::from_env()?;
+    info!("Job: {:#?}", job);
 
     /*
     use crate::access_times::{revert_folder, supports_atime};

--- a/src/cache_cargo_home.rs
+++ b/src/cache_cargo_home.rs
@@ -460,6 +460,7 @@ pub async fn restore_cargo_cache(input_manager: &input_manager::Manager) -> Resu
         // Delete derived content at any paths we want to restore cached items to
         for delete_path in find_additional_delete_paths(cache_type).await? {
             if delete_path.exists().await {
+                info!("Pruning redundant cache element: {}", delete_path);
                 actions::io::rm_rf(&delete_path).await?;
             }
         }

--- a/src/cache_cargo_home.rs
+++ b/src/cache_cargo_home.rs
@@ -585,6 +585,8 @@ pub async fn save_cargo_cache(input_manager: &input_manager::Manager) -> Result<
             cache.prune_unused(&cache_old).await?;
         }
 
+        info!("New group cache keys: {:#?}", cache.group_cache_keys());
+
         /*
         let mut folder_info_new = build_cached_folder_info(cache_type).await?;
         let folder_info_old: CachedFolderInfo = {

--- a/src/cache_cargo_home.rs
+++ b/src/cache_cargo_home.rs
@@ -105,6 +105,12 @@ impl Cache {
                 cache_type.friendly_name(),
                 restore_key
             );
+            let dep_file_path = dependency_file_path(cache_type, scope, &job)?;
+            let groups: Vec<GroupIdentifier> = {
+                let file_contents = node::fs::read_file(&dep_file_path).await?;
+                serde_json::de::from_slice(&file_contents)?
+            };
+            info!("We need to restore the following groups: {:#?}", groups);
             //TODO: We actually need to open the dependency list and try to
             // restore entries now
         } else {
@@ -123,7 +129,7 @@ impl Cache {
         let dep_file_path = dependency_file_path(self.cache_type, &scope_hash, &job)?;
         let old_groups = if dep_file_path.exists().await {
             let file_contents = node::fs::read_file(&dep_file_path).await?;
-            let old_groups: Vec<GroupIdentifier> = serde_json::de::from_slice(&file_contents)?;
+            let old_groups = serde_json::de::from_slice(&file_contents)?;
             Some(old_groups)
         } else {
             None

--- a/src/cache_key_builder.rs
+++ b/src/cache_key_builder.rs
@@ -2,7 +2,6 @@ use crate::actions::cache::Entry as CacheEntry;
 use crate::hasher::Blake3 as Blake3Hasher;
 use crate::safe_encoding;
 use std::collections::BTreeMap;
-use std::hash::Hasher as _;
 
 const CACHE_ENTRY_VERSION: &str = "6";
 
@@ -55,21 +54,15 @@ impl CacheKeyBuilder {
             }
             save_key += ")";
         }
-        let save_key = save_key.replace(',', ";");
-        save_key
+        save_key.replace(',', ";")
     }
 
-    pub fn current_save_key(&self) -> String {
-        self.restore_key_to_save_key(&self.current_restore_key())
-    }
-
-    pub fn current_restore_key(&self) -> String {
+    fn current_restore_key(&self) -> String {
         let id: [u8; 32] = self.hasher.inner().finalize().into();
         let id = &id[..8];
         let id = safe_encoding::encode(id);
         let restore_key = format!("Ferrous Actions: {} - id={}", self.name, id);
-        let restore_key = restore_key.replace(',', ";");
-        restore_key
+        restore_key.replace(',', ";")
     }
 
     pub fn into_entry(self) -> CacheEntry {

--- a/src/cache_key_builder.rs
+++ b/src/cache_key_builder.rs
@@ -4,7 +4,7 @@ use crate::safe_encoding;
 use std::collections::BTreeMap;
 use std::hash::Hasher as _;
 
-const CACHE_ENTRY_VERSION: &str = "5";
+const CACHE_ENTRY_VERSION: &str = "6";
 
 pub struct CacheKeyBuilder {
     name: String,

--- a/src/cargo_hooks/install.rs
+++ b/src/cargo_hooks/install.rs
@@ -1,7 +1,8 @@
 use super::Hook;
 use crate::action_paths::get_action_cache_dir;
 use crate::actions::cache::Entry as CacheEntry;
-use crate::fingerprinting::{render_delta_items, Fingerprint};
+use crate::delta::render_list as render_delta_list;
+use crate::fingerprinting::Fingerprint;
 use crate::hasher::Blake3 as Blake3Hasher;
 use crate::node::path::Path;
 use crate::{actions, error, info, node, warning, Error};
@@ -134,7 +135,7 @@ impl Hook for Install {
                             new_fingerprint.content_hash()
                         );
                         let delta = new_fingerprint.changes_from(old_fingerprint);
-                        info!("{}", render_delta_items(&delta));
+                        info!("{}", render_delta_list(&delta));
                     }
                     changed
                 }

--- a/src/cargo_hooks/install.rs
+++ b/src/cargo_hooks/install.rs
@@ -2,6 +2,7 @@ use super::Hook;
 use crate::action_paths::get_action_cache_dir;
 use crate::actions::cache::Entry as CacheEntry;
 use crate::fingerprinting::{render_delta_items, Fingerprint};
+use crate::hasher::Blake3 as Blake3Hasher;
 use crate::node::path::Path;
 use crate::{actions, error, info, node, warning, Error};
 use async_trait::async_trait;
@@ -32,14 +33,16 @@ impl Install {
         I: IntoIterator<Item = A>,
         A: AsRef<str>,
     {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(toolchain_hash.as_ref());
+        use std::hash::Hash as _;
+
+        let mut hasher = Blake3Hasher::default();
         let arg_string = {
+            toolchain_hash.hash(&mut hasher);
             let mut arg_string = String::new();
             let mut first = true;
             for arg in args {
                 let arg = arg.as_ref();
-                hasher.update(arg.as_bytes());
+                arg.hash(&mut hasher);
                 if first {
                     first = false;
                 } else {
@@ -49,7 +52,7 @@ impl Install {
             }
             arg_string
         };
-        let hash = hasher.finalize();
+        let hash = hasher.inner().finalize();
         let hash = HashValue::from_bytes(hash.as_bytes());
         let build_dir = get_package_build_dir(&hash)?;
         let mut result = Install {
@@ -88,7 +91,7 @@ impl Install {
         use crate::cache_key_builder::CacheKeyBuilder;
 
         let mut key_builder = CacheKeyBuilder::new("cargo install build artifacts");
-        key_builder.add_id_bytes(self.hash.as_ref());
+        key_builder.add_key_data(&self.hash);
         let arg_string = {
             let mut arg_string = self.arg_string.clone();
             if arg_string.len() > MAX_ARG_STRING_LENGTH {

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, strum::Display)]
+pub enum Action {
+    Added,
+    Removed,
+    Changed,
+}
+
+pub fn render_list<S>(items: &[(S, Action)]) -> String
+where
+    S: std::fmt::Display,
+{
+    use std::fmt::Write as _;
+    let mut result = String::new();
+    for (path, item) in items {
+        writeln!(&mut result, "{}: {}", item, path).expect("Unable to write to string");
+    }
+    result
+}

--- a/src/dir_tree.rs
+++ b/src/dir_tree.rs
@@ -79,6 +79,7 @@ struct PathMatchVisitor<'a> {
     matching_paths: Vec<Path>,
     matcher: &'a PathMatch,
     path_stack: VecDeque<Path>,
+    output_relative: bool,
 }
 
 impl<'a> PathMatchVisitor<'a> {
@@ -90,7 +91,8 @@ impl<'a> PathMatchVisitor<'a> {
 
     fn visit_path(&mut self, absolute: &Path, relative: &Path) {
         if self.matcher.matches(relative.to_string()) {
-            self.matching_paths.push(absolute.clone());
+            let path = if self.output_relative { relative } else { absolute }.clone();
+            self.matching_paths.push(path);
         }
     }
 }
@@ -126,11 +128,12 @@ impl<'a> Visitor for PathMatchVisitor<'a> {
     }
 }
 
-pub async fn match_relative_paths(path: &Path, matcher: &PathMatch) -> Result<Vec<Path>, Error> {
+pub async fn match_relative_paths(path: &Path, matcher: &PathMatch, output_relative: bool) -> Result<Vec<Path>, Error> {
     let mut visitor = PathMatchVisitor {
         matching_paths: Vec::new(),
         matcher,
         path_stack: VecDeque::new(),
+        output_relative,
     };
     let ignores = Ignores::default();
     apply_visitor(path, &ignores, &mut visitor).await?;

--- a/src/fingerprinting.rs
+++ b/src/fingerprinting.rs
@@ -1,3 +1,4 @@
+use crate::delta::Action as DeltaAction;
 pub use crate::dir_tree::Ignores;
 use crate::node::fs;
 use crate::node::path::{self, Path};
@@ -21,24 +22,6 @@ struct Metadata {
     mode: u64,
     modified: DateTime<Utc>,
     accessed: DateTime<Utc>,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, strum::Display)]
-pub enum DeltaAction {
-    Added,
-    Removed,
-    Changed,
-}
-
-pub type DeltaItem = (String, DeltaAction);
-
-pub fn render_delta_items(items: &[DeltaItem]) -> String {
-    use std::fmt::Write as _;
-    let mut result = String::new();
-    for (path, item) in items {
-        writeln!(&mut result, "{}: {}", item, path).expect("Unable to write to string");
-    }
-    result
 }
 
 impl From<&fs::Metadata> for Metadata {
@@ -167,7 +150,7 @@ impl Fingerprint {
         }
     }
 
-    pub fn changes_from(&self, other: &Fingerprint) -> Vec<DeltaItem> {
+    pub fn changes_from(&self, other: &Fingerprint) -> Vec<(String, DeltaAction)> {
         use itertools::Itertools as _;
 
         let from_iter = other.sorted_file_paths_and_metadata();

--- a/src/fingerprinting.rs
+++ b/src/fingerprinting.rs
@@ -322,7 +322,7 @@ pub async fn fingerprint_path_with_ignores(path: &Path, ignores: &Ignores) -> Re
     let result = Fingerprint {
         content_hash,
         modified: visitor.modified,
-        accessed: visitor.modified,
+        accessed: visitor.accessed,
         root,
     };
     Ok(result)

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,0 +1,30 @@
+use rust_toolchain_manifest::HashValue;
+
+#[derive(Debug, Default)]
+pub struct Blake3 {
+    inner: blake3::Hasher,
+}
+
+impl std::hash::Hasher for Blake3 {
+    fn finish(&self) -> u64 {
+        let mut xof = self.inner.finalize_xof();
+        let mut bytes = [0u8; 8];
+        xof.fill(&mut bytes);
+        u64::from_le_bytes(bytes)
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.inner.update(bytes);
+    }
+}
+
+impl Blake3 {
+    pub fn inner(&self) -> &blake3::Hasher {
+        &self.inner
+    }
+
+    pub fn hash_value(&self) -> HashValue {
+        let hash = self.inner.finalize();
+        HashValue::from_bytes(&hash.as_bytes()[..])
+    }
+}

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,0 +1,39 @@
+use crate::actions::core;
+use crate::Error;
+use serde::de::DeserializeOwned;
+use serde_json::Value as JsonValue;
+use std::collections::BTreeMap;
+
+const JOB_INPUT: &str = "internal-use-github-job";
+const MATRIX_INPUT: &str = "internal-use-matrix";
+const WORKFLOW_INPUT: &str = "internal-use-github-workflow";
+
+#[derive(Clone, Debug)]
+pub struct Job {
+    workflow: String,
+    job_id: String,
+    matrix_properties: BTreeMap<String, String>,
+}
+
+impl Job {
+    fn get_json_input<T>(name: &str) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        let input = core::Input::from(name).get_required()?;
+        Ok(serde_json::from_str(&input)?)
+    }
+
+    pub fn from_env() -> Result<Job, Error> {
+        let workflow = Self::get_json_input(WORKFLOW_INPUT)?;
+        let job_id = Self::get_json_input(JOB_INPUT)?;
+        let matrix_properties: Option<_> = Self::get_json_input(MATRIX_INPUT)?;
+        let matrix_properties = matrix_properties.unwrap_or_default();
+        let result = Job {
+            workflow,
+            job_id,
+            matrix_properties,
+        };
+        Ok(result)
+    }
+}

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,18 +1,17 @@
 use crate::actions::core;
 use crate::Error;
 use serde::de::DeserializeOwned;
-use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 
 const JOB_INPUT: &str = "internal-use-github-job";
 const MATRIX_INPUT: &str = "internal-use-matrix";
 const WORKFLOW_INPUT: &str = "internal-use-github-workflow";
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct Job {
     workflow: String,
     job_id: String,
-    matrix_properties: BTreeMap<String, String>,
+    matrix_properties: Option<BTreeMap<String, String>>,
 }
 
 impl Job {
@@ -27,13 +26,29 @@ impl Job {
     pub fn from_env() -> Result<Job, Error> {
         let workflow = Self::get_json_input(WORKFLOW_INPUT)?;
         let job_id = Self::get_json_input(JOB_INPUT)?;
-        let matrix_properties: Option<_> = Self::get_json_input(MATRIX_INPUT)?;
-        let matrix_properties = matrix_properties.unwrap_or_default();
+        let matrix_properties = Self::get_json_input(MATRIX_INPUT)?;
         let result = Job {
             workflow,
             job_id,
             matrix_properties,
         };
         Ok(result)
+    }
+
+    pub fn get_workflow(&self) -> &str {
+        &self.workflow
+    }
+
+    pub fn get_job_id(&self) -> &str {
+        &self.job_id
+    }
+
+    pub fn matrix_properties_as_string(&self) -> Option<String> {
+        // Note: This function does not attempt to guarantee that this string is
+        // deterministic. At the time of writing it is though, regardless of whether
+        // serde_json's "preserve_order" feature is on or off.
+        self.matrix_properties
+            .as_ref()
+            .map(|p| serde_json::to_string(p).expect("Failed to serialize a map of String to String to JSON"))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod cross;
 mod dir_tree;
 mod error;
 mod fingerprinting;
+mod hasher;
 mod input_manager;
 mod job;
 mod node;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod dir_tree;
 mod error;
 mod fingerprinting;
 mod input_manager;
+mod job;
 mod node;
 mod nonce;
 mod noop_stream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod cargo;
 mod cargo_hooks;
 mod cargo_lock_hashing;
 mod cross;
+mod delta;
 mod dir_tree;
 mod error;
 mod fingerprinting;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -33,7 +33,7 @@ fn compute_package_cache_key(package: &ManifestPackage) -> CacheEntry {
     use crate::cache_key_builder::CacheKeyBuilder;
 
     let mut builder = CacheKeyBuilder::new(&package.name);
-    builder.add_id_bytes(package.unique_identifier().as_ref());
+    builder.add_key_data(&package.unique_identifier());
     builder.set_attribute("target", &package.supported_target.to_string());
     builder.set_attribute("version", &package.version);
     builder.into_entry()


### PR DESCRIPTION
Reworks caching to be two level. Each job loads and saves a file which contains its dependencies, then the dependencies are cached separately. This avoids jobs competing with each other when they have different dependencies but allows some sharing between them when the dependencies are the same.